### PR TITLE
bit hacky message id handling

### DIFF
--- a/scripts/slack-email-digest.py
+++ b/scripts/slack-email-digest.py
@@ -195,6 +195,9 @@ def main():
         ), file=sys.stderr)
 
     scraper = SlackScraper(token, verbose=verbose)
+    team_id = scraper.get_team_id()
+    channel_id = scraper.get_channel_id(slack_channel)
+
     hist = scraper.get_channel_history(
         slack_channel,
         oldest=start_ts, latest=end_ts)
@@ -206,12 +209,9 @@ def main():
 
     # render emails, replying to the last day's digest, and setting the last
     # id to be reply-able from the next day's digest
-    in_reply_to = None
-    last_message_id = format_last_message_id(date)
-    if date.day > 1:
-        in_reply_to = format_last_message_id(date - datetime.timedelta(days=1))
-
-    emails = email_renderer.render_digest_emails(hist, in_reply_to=in_reply_to, last_message_id=last_message_id)
+    emails = email_renderer.render_digest_emails(
+        hist, date, team_id, channel_id,
+    )
     for email in emails:
         email['sender'] = ("%s <%s>" % (from_name, from_email)) if from_name else from_email
         email['to'] = to

--- a/slack_email_digest/SlackScraper.py
+++ b/slack_email_digest/SlackScraper.py
@@ -17,6 +17,10 @@ class SlackScraper(object):
 
         self.request_pause_period = 0.5
 
+    def get_team_id(self):
+        """:return The team ID for the Slack being accessed by this scraper."""
+        return self.slack.team.info().body['team']['id']
+
     def get_username(self, user_id):
         for name, info in self.users.items():
             if info['id'] == user_id:


### PR DESCRIPTION
Message ids now vary based on team_id and channel_id.

Really this should be refactored so there's just one slack instance, each of the piece use it to get the info instead of passing it around, the date is tied with the messages, etc. But it works for now!
